### PR TITLE
support thymeleaf layout by default

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -12,6 +12,7 @@
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <struts2.version>2.3.16.3</struts2.version>
         <thymeleaf.version>2.1.3.RELEASE</thymeleaf.version>
+        <thymeleaf-layout-dialect.version>1.2.7</thymeleaf-layout-dialect.version>
     </properties>
 
     <repositories>
@@ -38,6 +39,12 @@
             <groupId>org.thymeleaf</groupId>
             <artifactId>thymeleaf</artifactId>
             <version>${thymeleaf.version}</version>
+        </dependency>
+
+        <dependency>
+            <groupId>nz.net.ultraq.thymeleaf</groupId>
+            <artifactId>thymeleaf-layout-dialect</artifactId>
+            <version>${thymeleaf-layout-dialect.version}</version>
         </dependency>
     </dependencies>
     <build>

--- a/src/main/java/org/codework/struts/plugins/thymeleaf/spi/DefaultTemplateEngineProvider.java
+++ b/src/main/java/org/codework/struts/plugins/thymeleaf/spi/DefaultTemplateEngineProvider.java
@@ -19,6 +19,7 @@ import com.opensymphony.xwork2.inject.Inject;
 import org.codework.struts.plugins.thymeleaf.StrutsMessageResolver;
 import org.thymeleaf.TemplateEngine;
 import org.thymeleaf.templateresolver.ServletContextTemplateResolver;
+import nz.net.ultraq.thymeleaf.LayoutDialect;
 
 /**
  * A default implementation of {@link TemplateEngineProvider}.
@@ -56,6 +57,7 @@ public class DefaultTemplateEngineProvider implements TemplateEngineProvider {
 
     templateEngine = new TemplateEngine();
     templateEngine.setTemplateResolver(templateResolver);
+    templateEngine.addDialect(new LayoutDialect());
     templateEngine.setMessageResolver(new StrutsMessageResolver());
   }
 


### PR DESCRIPTION
Hi. This is a proposition for supporting thymeleaf layout.

As you know thymeleaf-layout-dialect is a very useful add-on, and spring-boot-starter-thymeleaf is also supporting it by default.

Hoping your plugin also support it.

Regards